### PR TITLE
added Hyperbolic System Dependent postprocessing step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build*
 .cache
+/doc
+.cproject
+.project
+.settings/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,41 @@ if(NOT DEAL_II_WITH_MPI OR NOT DEAL_II_WITH_P4EST)
     )
 endif()
 
+#
+# Find braid
+#
+
+# Find braid details
+IF(NOT "$ENV{BRAID_DIR}" STREQUAL "")
+    SET(BRAID_DIR "$ENV{BRAID_DIR}" CACHE INTERNAL "Copied BRAID_DIR from environment variable")
+ENDIF()
+
+IF("${CMAKE_FIND_LIBRARY_PREFIXES}" STREQUAL "")
+    SET(CMAKE_FIND_LIBRARY_PREFIXES "lib")
+ENDIF()
+
+FIND_PATH(BRAID_INCLUDE_DIR
+  NAMES braid.h
+  HINTS ${BRAID_DIR}
+  PATH_SUFFIXES include
+  )
+
+FIND_LIBRARY(BRAID_LIBRARY
+  NAMES libbraid.a
+  HINTS ${BRAID_DIR}
+  PATH_SUFFIXES lib64 lib
+  )
+
+MESSAGE(STATUS "Braid include directory: ${BRAID_INCLUDE_DIR}")
+MESSAGE(STATUS "Braid library:           ${BRAID_LIBRARY}")
+MESSAGE(STATUS "Dealii library: 	 ${DEAL_II_DIR}")
+# Include the braid paths and libraries
+INCLUDE_DIRECTORIES(${BRAID_INCLUDE_DIR})
+
+
+#
+# Declare project target and code language
+#
 project(ryujin CXX)
 
 #
@@ -157,6 +192,7 @@ endif()
 include(GNUInstallDirs)
 
 add_subdirectory(source)
+
 
 install(FILES COPYING.md README.md
   DESTINATION ${CMAKE_INSTALL_DOCDIR}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -88,9 +88,25 @@ endforeach()
 add_executable(ryujin main.cc)
 deal_ii_setup_target(ryujin)
 target_link_libraries(ryujin obj_common ${OBJECT_TARGETS} ${EXTERNAL_TARGETS})
-
 set_target_properties(ryujin PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/run"
   )
 
 install(TARGETS ryujin DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+#
+#Add Xbraid library and also set up my executable
+#
+
+
+
+add_executable(high-order-euler high-order-euler.cc)
+deal_ii_setup_target(high-order-euler)
+target_link_libraries(high-order-euler obj_common ${OBJECT_TARGETS} ${EXTERNAL_TARGETS})
+set_target_properties(high-order-euler PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/run"
+  )
+
+install(TARGETS high-order-euler DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -18,6 +18,9 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/tensor.h>
 
+#include <mpi.h>
+#include <offline_data.h>
+
 #include <array>
 #include <functional>
 
@@ -709,6 +712,15 @@ namespace ryujin
         state_type apply_galilei_transform(const state_type &state,
                                            const Lambda &lambda) const;
         //@}
+
+        /**
+         * system dependent postprocessing step @p U is our solution state
+         * and we will define work to do on this which is Hyperbolic System Dependent
+         *
+         * Here, we do nothing.
+         */
+        void post_process(const vector_type &U, Number t, MPI_Comm, const ryujin::OfflineData<dim, Number>&) const;
+
       }; /* HyperbolicSystem::View */
 
       template <int dim, typename Number>
@@ -1454,5 +1466,16 @@ namespace ryujin
         result[1 + d] = M[d];
       return result;
     }
+
+
+    template<int dim, typename Number>
+    void HyperbolicSystem::View<dim, Number>::post_process(const vector_type &U,
+                                                           Number t,
+                                                           MPI_Comm mpi_communicator,
+                                                           const ryujin::OfflineData<dim, Number>& offline_data_) const
+    {
+      //does nothing
+    }
+
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/high-order-euler.cc
+++ b/source/high-order-euler.cc
@@ -1,0 +1,698 @@
+/*
+ * Using ryujin for the higher order Euler simulation of
+ * a mach 3 flow around a cylinder.
+ */
+
+//includes
+#include <iostream>
+#include <filesystem>
+#include <cassert>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <iomanip>
+#include <cassert>
+#include <cmath>
+#include <vector>
+#include <memory>
+
+//MPI
+#include <deal.II/base/mpi.h>
+
+//ryujin includes
+//#include "hyperbolic_module.h"
+//#include "offline_data.h"
+//#include "geometry_cylinder.h"
+//#include "discretization.h"
+#include "hyperbolic_system.h"
+#include "time_loop.h"
+#include "euler/description.h"
+#include "convenience_macros.h"
+#include <description.h>
+
+//deal.II includes
+#include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/mpi.h>
+
+//xbraid include
+#include <braid.h>
+#include <braid_test.h>
+
+/*
+ * Author: Jerett Cherry, Colorado State University
+ */
+
+const int dim = 2;
+/**
+ *   \brief Contains the implementation of the mandatory X-Braid functions
+ *
+ *  X-Braid mandates several functions in order to drive the solution.
+ *  This file contains the implementation of said mandatory functions.
+ *  See the X-Braid documentation for more information.
+ *  There are several functions that are optional in X-Braid that may
+ *  or may not be implemented in here.
+ */
+
+/*Includes*/
+
+/*-------- Third Party --------*/
+#include <deal.II/numerics/vector_tools.h>
+
+/*-------- Project --------*/
+//#include "offlinedata.h"
+//#include "parallel-in-time-euler.h"
+
+// This preprocessor macro is used on function arguments
+// that are not used in the function. It is used to
+// suppress compiler warnings.
+#define UNUSED(x) (void)(x)
+
+/**
+ * This function should take a vector and resize it with
+ * the size specified
+ */
+
+template<typename Description, typename V, int dim>
+void resizeVector(V& v,
+                  const int size,
+                  const int num_comps = ryujin::TimeLoop<Description,
+                                                         dim,
+                                                         NUMBER>::problem_dimension)
+{
+  for(int i = 0; i < num_comps; ++i)
+    v[i].reinit(size);
+}
+
+
+// This struct contains all data that changes with time. For now
+// this is just the solution data. When doing AMR this should
+// probably include the triangulization, the sparsity patter,
+// constraints, etc.
+/**
+ * \brief Struct that contains the deal.ii vector of size (dim+2,n_dofs).
+ */
+typedef struct _braid_Vector_struct
+{
+  ryujin::TimeLoop<ryujin::Euler::Description, dim, NUMBER>::vector_type U;
+
+} my_Vector;
+
+// This struct contains all the data that is unchanging with time.
+/**
+ * \brief Struct that contains the HeatEquation and final
+ * time step number.
+ *
+ * XBRAID uses this app structure as information that each
+ * process can use when computing, so naturally should be
+ * used to store global information relevant to each
+ * process.
+ *
+ * The app stores spatial and temporal communicators,
+ * comm_x and comm_t. (For this code, we use MPI_COMM_SELF for
+ * comm_x, and MPI_COMM_WORLD for comm_t. For maximum performance,
+ * one needs to leverage the spatial parallelism that is build in
+ * to step-69, and coordinate with the additional parallelism grant-
+ * ed by XBRAID. To do this, one should use a custom communicator
+ * for comm_x, but MPI_COMM_WORLD is a natural choice for comm_t
+ * since it oversees the communication between 'time bricks'.
+ *
+ * For step-69 to run parallel in time, one needs only to store
+ * objects like the sparsity pattern, dof-handler, etc once.
+ * Then, this information can be queried by the individual
+ * processors doing the work. This information is stored in
+ * the TimeIndependent class--reference its documentation.
+ *
+ * XBRAID
+ */
+
+typedef struct _braid_App_struct
+{
+//  public:
+//    MPI_Comm comm_x, comm_t;
+////    TimeIndependent<dim> TI;
+//    std::vector<std::shared_ptr<TimeIndependent<dim>>> TI_p;
+//    int final_step, mg_cycle;
+//    int mg_level;//FIXME remove this
+//    std::vector<unsigned int> refinement_levels;
+//    int vect_size, finest_index, coarsest_index, n_solution_variables;
+//    _braid_App_struct(MPI_Comm mpi_comm_x,
+//                      const MPI_Comm comm_t,
+//                      int final_step,
+//                      const unsigned int mg_level,
+//                      const std::vector<unsigned int> refine_levels)
+//    : comm_x(mpi_comm_x),
+//      comm_t(comm_t),
+//      TI_p(refine_levels.size()),
+//      final_step(final_step),
+//      mg_cycle(0),//cycle starts at 0 since there has been no cycles yet
+//      mg_level(mg_level),
+//      refinement_levels(refine_levels)
+//    {
+//      //assert that user specified levels vector is ordered properly
+//      for(unsigned int i = 0; i < refinement_levels.size()-1; ++i)
+//      {
+//        assert(refinement_levels.at(i) <= refinement_levels.at(i+1)
+//            && "in testcase.prm the levels need to be in increasing order");
+//      }
+//
+//      finest_index = 0;
+//      int last_index = refinement_levels.size()-1;
+//      coarsest_index = last_index;
+//      for (unsigned int i=0; i<refinement_levels.size(); i++)
+//      {
+//        std::cout << "_____________________________\n";
+//        std::cout << "Refinement i=" << i << "\n";
+//        /*set up the array of time independent objects.*/
+//
+//        //the finest level should be at level 0 (i=0), ensuring that level queries
+//        //later on match the xbraid standard
+//        TI_p.at(i) = std::make_shared<TimeIndependent<dim>>(mpi_comm_x,
+//                                                            comm_t,
+//                                                            refinement_levels.at(last_index - i));
+//        /*new*/
+//        TI_p[i]->pcout << "Reading parameters and allocating objects... " << std::flush;
+//        TI_p[i]->pcout << "done" << std::endl;
+//        {
+//          print_head(TI_p[i]->pcout, "create triangulation");
+//
+//          TI_p[i]->discretization.setup();
+//
+//          if (TI_p[i]->resume)
+//            TI_p[i]->discretization.triangulation.load(TI_p[i]->base_name + "-checkpoint.mesh");
+//          else
+//            TI_p[i]->discretization.triangulation.refine_global(TI_p[i]->discretization.refinement);
+//
+//          TI_p[i]->pcout << "Number of active cells:       "
+//              << TI_p[i]->discretization.triangulation.n_global_active_cells()
+//              << std::endl;
+//
+//          //FIXME this piece should be the same for every process, find a way to break it out.
+//          print_head(TI_p[i]->pcout, "compute offline data");
+//          TI_p[i]->offline_data.setup();
+//          TI_p[i]->offline_data.assemble();//FIXME to here, we should not need anything past this??
+//
+//          TI_p[i]->pcout << "Number of degrees of freedom: "
+//              << TI_p[i]->offline_data.dof_handler.n_dofs() << std::endl;
+//
+//          print_head(TI_p[i]->pcout, "set up time step");
+//          TI_p[i]->time_stepping.prepare();
+//          TI_p[i]->schlieren_postprocessor.prepare();
+//        }
+//      }//loop
+//      vect_size =  TI_p.at(finest_index)->offline_data.dof_handler.n_dofs();
+//      n_solution_variables = ProblemDescription<dim>::n_solution_variables;
+//      ParameterAcceptor::initialize("step-69.prm");
+//
+//      std::cout << "APP created.\n";
+//      /*new end*/
+//    };
+} my_App;
+
+
+/**
+ * @brief This function is used to interpolate a vector (from_V) on a certain mesh
+ *        to a nother interpolated solution on another mesh.
+ *
+ * @param[out] to_v, the vector V to which we are interpolating the solution
+ * @param[in]  the mg level we are interpolating to
+ * @param[in]  from_V the vector storing the solution we wish to interpolate
+ * @param[in]  from_level the mg level which currently stores the solution
+ * @param[in]  app, the user defined app which stores needed information about the mg levels
+ *
+ * NOTE: this function only works if the vectors to_v and from_v have an at() method implemented.
+ */
+template<typename V>
+void interpolateUBetweenLevels(V& to_v,
+                               const int to_level,
+                               const V& from_v,
+                               const int from_level,
+                               braid_App& app)
+{
+//  assert(to_v.at(0).size() == app->TI_p[to_level]->offline_data.dof_handler.n_dofs()
+//      && "trying to interpolate to a vactor and level where the n_dofs do not match");
+//
+//  unsigned int n_solution_variables = ProblemDescription<dim>::n_solution_variables;//constant at any dimension
+//  for(unsigned int comp=0; comp<n_solution_variables; comp++)
+//    {
+//      VectorTools::interpolate_to_different_mesh(app->TI_p[from_level]->offline_data.dof_handler,
+//                                                 from_v.at(comp),
+//                                                 app->TI_p[to_level]->offline_data.dof_handler,
+//                                                 to_v.at(comp));
+//    }
+}
+
+/**
+ * @brief my_Step - Creates new eulerproblem object, calls run_with_initial_data(...) and updates U.
+ *
+ * @param app - The braid app struct
+ * @param ustop - The solution data at the end of this time step
+ * @param fstop - RHS data (such as forcing function?)
+ * @param u - The solution data at the beginning of this time step
+ * @param status - Status structure that contains various info of this time
+ *
+ * @return Success (0) or failure (1)
+ **/
+int my_Step(braid_App        app,
+            braid_Vector     ustop,
+            braid_Vector     fstop,
+            braid_Vector     u,
+            braid_StepStatus status)
+{
+//  //this variable is used for writing data to
+//  //different files during the parallel computations.
+//  //is passed to run_with_initial_data
+//  static unsigned int num_step_calls = 0;
+//  std::cout << "step called\n";
+//
+//  //grab the MG level for this step
+//  int level;
+//  braid_StepStatusGetLevel(status, &level);
+//  std::cout << "with level= " << level << std::endl;
+//
+//  //use a macro to get rid of some unused variables to avoid -Wall messages
+//  UNUSED(ustop);
+//  UNUSED(fstop);
+//  //grab the start time and end time
+//  double tstart;
+//  double tstop;
+//  braid_StepStatusGetTstartTstop(status, &tstart, &tstop);
+//
+//  //translate the fine level u to the coarse level
+//  //this uses a function from DEALII interpolate to different mesh
+//  EulerEquation<dim>::vector_type u_to_step;
+//  int coarse_size = app->TI_p.at(level)->offline_data.dof_handler.n_dofs();
+//  resizeVector(u_to_step,coarse_size);
+//
+//  //interpolate the data coming in with u (finest level) onto the
+//  //u_to_step (coarse level)
+//  interpolateUBetweenLevels(u_to_step,
+//                            level,
+//                            u->data,
+//                            app->finest_index,
+//                            app);
+//
+//
+//  //set up the object that is going to do the time stepping
+//  //the vector size here should match that of the right level.
+//  EulerEquation<dim> eq(app->TI_p[level], tstart, tstop);
+//
+//  //set the level
+//  eq.setLevel(level);
+//
+//  //set the mg_cycle
+//  eq.setCycle(app->mg_cycle);
+//
+//  std::cout << "_____________Level: " << level << "\n"
+//            << "ndof at this level: " << eq.get_size() << std::endl;
+//  //update u_interpolated with a step
+//  u_to_step = eq.run_with_initial_data(u_to_step,
+//                                       tstart,
+//                                       tstop,
+//                                       num_step_calls);
+//  ++num_step_calls;
+//
+//  //now that we have completed the step, we interpolate back to the
+//  //finest level from the current level and coarse solution
+//  interpolateUBetweenLevels(u->data,
+//                            app->finest_index,
+//                            u_to_step,
+//                            level,
+//                            app);
+//  //now u is updated with the stepped solution.
+////  std::cout << "Number of my step calls: " << num_step_calls << "\n";
+//  return 0;
+};
+
+
+/**
+ * @brief my_Init - Initializes a solution data at the given time
+ * For this, the init function initializes each time point with a coarsest grid calculation of the solution.
+ *
+ * @param app - The braid app struct containing user data
+ * @param t - Time at which the solution is initialized
+ * @param u_ptr - The solution data that needs to be filled
+ *
+ * @return Success (0) or failure (1)
+ **/
+int
+my_Init(braid_App     app,
+        double        t,
+        braid_Vector *u_ptr)
+{
+//  std::cout << "Init called.\n";
+//
+//  //static unsigned int initcall = 0;
+//  my_Vector *u = new(my_Vector);
+//  //initializes all at a fine level
+//  resizeVector(u->data, app->vect_size);
+//
+//  //if t is not zero, we integrate the initial solution from 0->t on the coarsest level, and
+//  //get a coarse solution.
+//  if(std::abs(t-0) > 1e-10)//NOTE: FIXME?: this could in theory cause problems when the time bricks are so many that one has an end time before 10^-10.
+//  {
+//    //create the time stepping object
+//    EulerEquation<dim> eq(app->TI_p[app->coarsest_index], 0, t);
+//    std::unique_ptr<my_Vector> u_coarse = std::make_unique<my_Vector>();//coarse vector
+//    resizeVector(u_coarse->data,
+//                 app->TI_p[app->coarsest_index]->offline_data.dof_handler.n_dofs());
+//
+//    //interpolate the fine mesh to the appropriate mesh
+//    interpolateUBetweenLevels(u_coarse->data, app->coarsest_index,
+//                              u->data, app->finest_index,
+//                              app);
+//    //run with initial data
+//    std::cout << "end time " << t << std::endl;
+//    eq.run_with_initial_data(u_coarse->data, 0, t, 0, false);
+//
+//    //interpolate the coarse mesh back to the fine mesh.
+//    interpolateUBetweenLevels(u->data, app->finest_index,
+//                              u_coarse->data,app->coarsest_index,
+//                              app);
+//  }
+////  //else do nothing to U, as we will initialize time = 0 inside the run function.
+////  EulerEquation<dim> eq(app->TI_p[app->finest_index], 0, t);
+////  unsigned int procID = Utilities::MPI::this_mpi_process(app->comm_t);
+////  eq.call = initcall++;
+////  eq.output(u->data, "init_test", t, procID);
+//
+//  *u_ptr = u;
+//
+//  return 0;
+}
+
+
+/**
+ * @brief my_Clone - Clones a vector into a new vector
+ *
+ * @param app - The braid app struct containing user data
+ * @param u - The existing vector containing data
+ * @param v_ptr - The empty vector that needs to be filled
+ *
+ * @return Success (0) or failure (1)
+ **/
+int
+my_Clone(braid_App     app,
+         braid_Vector  u,
+         braid_Vector *v_ptr)
+{
+//  std::cout << "Clone called" << std::endl;
+//  UNUSED(app);
+//  my_Vector *v = new(my_Vector);
+//  int size = u->data[0].size();
+////  Assert(size == app->TI.offline_data.dof_handler.n_dofs(),
+////      "size of cloned vector does not match the number of dof's. It should.");
+//
+//  for(unsigned int i=0;
+//        i < ProblemDescription<dim>::n_solution_variables;
+//        ++i)
+//    {
+//      v->data.at(i).reinit(size);
+//    }
+//
+//  for(unsigned int i=0;
+//          i < ProblemDescription<dim>::n_solution_variables;
+//          ++i)
+//      {
+//        v->data.at(i) = u->data.at(i);
+//      }
+//    *v_ptr = v;
+//    return 0;
+}
+
+
+/**
+ * @brief my_Free - Deletes a vector
+ *
+ * @param app - The braid app struct containing user data
+ * @param u - The vector that needs to be deleted
+ *
+ * @return Success (0) or failure (1)
+ **/
+int
+my_Free(braid_App    app,
+        braid_Vector u)
+{
+  std::cout << "Free called" << std::endl;
+  UNUSED(app);
+  delete u;
+
+  return 0;
+}
+
+
+/**
+ * @brief my_Sum - Sums two vectors in an AXPY operation sums on the finer of the two levels.
+ * The operation is y = alpha*x + beta*y
+ *
+ * @param app - The braid app struct containing user data
+ * @param alpha - The coefficient in front of x
+ * @param x - A vector that is multiplied by alpha then added to y
+ * @param beta - The coefficient of y
+ * @param y - A vector that is multiplied by beta then summed with x
+ *
+ * @return Success (0) or failure (1)
+ **/
+int
+my_Sum(braid_App app,
+       double alpha,
+       braid_Vector x,
+       double beta,
+       braid_Vector y)
+{
+//  std::cout << "Sum called\n";
+//  UNUSED(app);
+//  LinearAlgebra::distributed::Vector<double> tmp1, tmp2;
+//  int x_size = x->data[0].size();//size of x
+//  int y_size = y->data[0].size();
+//  assert(x_size == y_size && "adding vectors of different sizes will not work");
+//
+//  tmp1.reinit(x_size);
+//  tmp2.reinit(y_size);
+//  for(unsigned int i=0;
+//      i < ProblemDescription<dim>::n_solution_variables;
+//      ++i)
+//  {
+//    tmp1 = x->data.at(i);
+//    tmp2 = y->data.at(i);
+//    tmp1*=alpha;
+//    tmp2*=beta;
+//    tmp1+=tmp2;
+//
+//    y->data.at(i) = tmp1;
+//  }
+//
+//  return 0;
+}
+
+/**
+ *  \brief Returns the spatial norm of the provided vector
+ *
+ *  Calculates and returns the spatial norm of the provided vector.
+ *  Interestingly enough, X-Braid does not specify a particular norm.
+ *  to keep things simple, we implement the Euclidean norm.
+ *
+ *  \param app - The braid app struct containing user data
+ *  \param u - The vector we need to take the norm of
+ *  \param norm_ptr - Pointer to the norm that was calculated, need to modify this
+ *  \return Success (0) or failure (1)
+ */
+int
+my_SpatialNorm(braid_App     app,
+               braid_Vector  u,
+               double       *norm_ptr)
+{
+//  std::cout << "Norm called" << std::endl;
+//  UNUSED(app);
+//  double l2 = 0;
+//  for(unsigned int i=0;
+//        i < ProblemDescription<dim>::n_solution_variables;
+//        ++i)
+//    {
+//      l2 +=u->data.at(i).norm_sqr();
+//    }
+//  *norm_ptr = std::sqrt(l2);
+//
+//  return 0;
+}
+
+/**
+ *  \brief Allows the user to output details
+ *
+ *  The Access function is called at various points to allow the user to output
+ *  information to the screen or to files.
+ *  The astatus parameter provides various information about the simulation,
+ *  see the XBraid documentation for details on what information you can get.
+ *  Example information is what the current timestep number and current time is.
+ *  If the access level (in parallel_in_time.cc) is set to 0, this function is
+ *  never called.
+ *  If the access level is set to 1, the function is called after the last
+ *  XBraid cycle.
+ *  If the access level is set to 2, it is called every XBraid cycle.
+ *
+ *  \param app - The braid app struct containing user data
+ *  \param u - The vector containing the data at the status provided
+ *  \param astatus - The Braid status structure
+ *  \return Success (0) or failure (1)
+ */
+int
+my_Access(braid_App          app,
+          braid_Vector       u,
+          braid_AccessStatus astatus)
+{
+//  static int mgCycle = 0;
+//  std::cout << "Access called" << std::endl;
+//  //get the iteration
+//  braid_AccessStatusGetIter(astatus, &mgCycle);
+//  std::cout << "Cycles done: " << mgCycle << std::endl;
+//  app->mg_cycle = mgCycle;
+//  UNUSED(u);
+//  UNUSED(astatus);
+//
+//  //for now, we just increment the mg_cycle
+//
+//  return 0;
+}
+
+/**
+ *  \brief Calculates the size of a buffer for MPI data transfer
+ *
+ *  Calculates the size of the buffer that is needed to transfer
+ *  a solution vector to another processor.
+ *  The bstatus parameter provides various information on the
+ *  simulation, see the XBraid documentation for all possible
+ *  fields.
+ *
+ *  \param app - The braid app struct containing user data
+ *  \param size_ptr A pointer to the calculated size
+ *  \param bstatus The XBraid status structure
+ *  \return Success (0) or failure (1)
+ */
+int
+my_BufSize(braid_App           app,
+           int                 *size_ptr,
+           braid_BufferStatus  bstatus)
+{
+//  UNUSED(bstatus);
+//  int size = app->vect_size * app->n_solution_variables;//no vector can be bigger than this, so we are very conservative.
+//  *size_ptr = (size+1) * sizeof(double);//all values are doubles +1 is for the size of the buffers
+//  return 0;
+}
+
+/**
+ *  \brief Linearizes a vector to be sent to another processor
+ *
+ *  Linearizes (packs) a data buffer with the contents of
+ *  some solution state u.
+ *
+ *  \param app - The braid app struct containing user data
+ *  \param u The vector that must be packed into buffer
+ *  \param buffer The buffer that must be filled with u
+ *  \param bstatus The XBraid status structure
+ *  \return Success (0) or failure (1)
+ */
+int
+my_BufPack(braid_App           app,
+           braid_Vector        u,
+           void               *buffer,
+           braid_BufferStatus  bstatus)
+{
+//  std::cout << "Buff pack called" << std::endl;
+//  UNUSED(app);
+//  double *dbuffer = (double*)buffer;
+//
+//  unsigned int n_dof = app->vect_size;//number of dofs at fines level
+//  assert(n_dof == u->data.at(0).size() && "the number of degrees of freedom do not match");
+//  unsigned int n_solution_variables = app->TI_p[0]->time_stepping.n_solution_variables;//total problem dimension.(spacedim + density + energy)
+//  unsigned int buf_size = n_dof * n_solution_variables;
+//  dbuffer[0] = buf_size + 1;//buffer + size
+//
+//  for(unsigned int j=0; j < n_solution_variables; ++j)
+//  {
+//    for(unsigned int i=0; i != n_dof; ++i)
+//    {
+//      dbuffer[j*n_dof + i + 1] = (u->data).at(j)(i);
+//    }
+//  }
+//
+//  braid_BufferStatusSetSize(bstatus, (buf_size+1)*sizeof(double));
+//
+//  return 0;
+}
+
+/**
+ *  \brief Unpacks a vector that was sent from another processor
+ *
+ *  Unpacks a linear data buffer into the vector pointed to by
+ *  u_ptr.
+ *
+ *  \param app - The braid app struct containing user data
+ *  \param buffer The buffer that must be unpacked
+ *  \param u_ptr The pointer to the vector that is filled
+ *  \param bstatus The XBraid status structure
+ *  \return Success (0) or failure (1)
+ */
+int
+my_BufUnpack(braid_App           app,
+             void               *buffer,
+             braid_Vector       *u_ptr,
+             braid_BufferStatus  bstatus)
+{
+//  // the vector should be size (dim + 2) X n_dofs at finest level.
+//  std::cout << "buff unpack called\n";
+//  UNUSED(bstatus);
+//  my_Vector *u = NULL; // the vector we will pack the info into
+//  double *dbuffer = (double*)buffer;
+//  int buf_size = static_cast<int>(dbuffer[0]);
+//
+//  u = new(my_Vector);//where does this get deleted?
+//
+//  resizeVector(u->data, app->vect_size, app->n_solution_variables);
+//
+//  //unpack the sent data into the right level
+//  for(int j=0; j < app->n_solution_variables; ++j)
+//  {
+//    for(int i = 0; i < app->vect_size; ++i)
+//    {
+//      u->data.at(j)(i) = dbuffer[j*app->vect_size + i + 1];//+1 because buffer_size = n_dof + 1
+//      assert(j*app->vect_size + i +1 <= buf_size && "somehow, you are exceeding the buffer size as you unpack");
+//    }
+//  }
+//
+//  *u_ptr = u;//modify the u_ptr does this create a memory leak as we just point this pointer somewhere else?
+//
+//  std::cout << "Buffunpack done." << std::endl;
+//  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  MPI_Comm comm = MPI_COMM_WORLD;
+  MPI_Init(&argc, &argv);
+  //create objects
+
+  std::cout << "File Exists: " << std::filesystem::exists("cylinder-parameters.prm") << std::endl;
+  my_Vector vect;
+  ryujin::Discretization<2> discretization(comm,"C - Discretization");
+  //HyperbolicSystem<dim> hyperbolic_system();
+
+  std::cout << "parameter file name "  << argv[1] << std::endl;
+  //set the parameters
+  dealii::ParameterAcceptor::prm.parse_input("cylinder-parameters.prm",
+                                             "",
+                                             /*skip undefined*/true,
+                                             /*assert entries present*/false);
+
+  dealii::ParameterAcceptor::initialize(argv[1]);
+
+  std::cout << discretization.order_finite_element << std::endl;
+
+
+  //prepare objects after parameters have been set.
+  //discretization.prepare();
+
+
+
+
+
+
+  std::cout << "compiling with found header" << std::endl;
+}

--- a/source/high-order-euler.cc
+++ b/source/high-order-euler.cc
@@ -27,7 +27,6 @@
 #include "time_loop.h"
 #include "euler/description.h"
 #include "convenience_macros.h"
-#include <description.h>
 
 //deal.II includes
 #include <deal.II/base/parameter_acceptor.h>
@@ -670,29 +669,20 @@ int main(int argc, char *argv[])
   //create objects
 
   std::cout << "File Exists: " << std::filesystem::exists("cylinder-parameters.prm") << std::endl;
-  my_Vector vect;
-  ryujin::Discretization<2> discretization(comm,"C - Discretization");
+//  ryujin::Discretization<2> discretization(comm,"C - Discretization");
   //HyperbolicSystem<dim> hyperbolic_system();
 
   std::cout << "parameter file name "  << argv[1] << std::endl;
   //set the parameters
-  dealii::ParameterAcceptor::prm.parse_input("cylinder-parameters.prm",
-                                             "",
-                                             /*skip undefined*/true,
-                                             /*assert entries present*/false);
+//  dealii::ParameterAcceptor::prm.parse_input("cylinder-parameters.prm",
+//                                             "",
+//                                             /*skip undefined*/true,
+//                                             /*assert entries present*/false);
 
-  dealii::ParameterAcceptor::initialize(argv[1]);
+  ryujin::TimeLoop<ryujin::Euler::Description, 2, NUMBER> timeloop(comm);
+  dealii::ParameterAcceptor::initialize("cylinder-parameters.prm");//initialize the file specified by the user
 
-  std::cout << discretization.order_finite_element << std::endl;
-
-
-  //prepare objects after parameters have been set.
-  //discretization.prepare();
+  timeloop.run();
 
 
-
-
-
-
-  std::cout << "compiling with found header" << std::endl;
 }

--- a/source/high-order-euler.cc
+++ b/source/high-order-euler.cc
@@ -668,16 +668,7 @@ int main(int argc, char *argv[])
   MPI_Init(&argc, &argv);
   //create objects
 
-  std::cout << "File Exists: " << std::filesystem::exists("cylinder-parameters.prm") << std::endl;
-//  ryujin::Discretization<2> discretization(comm,"C - Discretization");
-  //HyperbolicSystem<dim> hyperbolic_system();
-
-  std::cout << "parameter file name "  << argv[1] << std::endl;
-  //set the parameters
-//  dealii::ParameterAcceptor::prm.parse_input("cylinder-parameters.prm",
-//                                             "",
-//                                             /*skip undefined*/true,
-//                                             /*assert entries present*/false);
+  //todo: change this to a call to something similar to the main ryujin executable. problem_dispach??
 
   ryujin::TimeLoop<ryujin::Euler::Description, 2, NUMBER> timeloop(comm);
   dealii::ParameterAcceptor::initialize("cylinder-parameters.prm");//initialize the file specified by the user

--- a/source/high-order-euler.cc
+++ b/source/high-order-euler.cc
@@ -684,5 +684,7 @@ int main(int argc, char *argv[])
 
   timeloop.run();
 
+  MPI_Finalize();
+
 
 }

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -142,6 +142,16 @@ namespace ryujin
     void compute(const vector_type &U) const;
 
     /**
+     * Given a current state @p U and a return type @p r_type
+     * compute a hyperbolic system dependent postprocessing step.
+     *
+     * This does nothing for EulerAEOS, Navier_stokes, scalar_conservation, shallow water, and skeleton
+     *
+     * For Euler, it does a drag and lift calculation, and prints this info out.
+     */
+    void post_process_data(const vector_type &U, Number t);
+
+    /**
      * Returns a reference to the quantities_ vector that has been filled
      * by the compute() function.
      */

--- a/source/postprocessor.template.h
+++ b/source/postprocessor.template.h
@@ -314,4 +314,16 @@ namespace ryujin
     }
   }
 
+  template<typename Description, int dim, typename Number>
+  void
+  Postprocessor<Description, dim, Number>::post_process_data(const vector_type &U, Number t)
+  {
+#ifdef DEBUG_OUTPUT
+    std::cout << "Postprocessor<dim, Number>::post_process_data()" << std::endl;
+#endif
+
+    const auto view = hyperbolic_system_->template view<dim, Number>();
+    view.post_process(U, t, mpi_communicator_, *offline_data_);
+  }
+
 } // namespace ryujin

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -18,6 +18,9 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/tensor.h>
 
+#include <mpi.h>
+#include <offline_data.h>
+
 #include <array>
 
 namespace ryujin
@@ -528,6 +531,13 @@ namespace ryujin
           return state;
         }
 
+        /**
+         * system dependent postprocessing step @p U is our solution state
+         * and we will define work to do on this which is Hyperbolic System Dependent
+         *
+         * Here, we do nothing
+         */
+        void post_process(const vector_type &U, Number t, MPI_Comm, const ryujin::OfflineData<dim, Number>&) const;
       }; /* HyperbolicSystem::View */
 
       template <int dim, typename Number>
@@ -889,6 +899,17 @@ namespace ryujin
     {
       return -add(flux_i, flux_j);
     }
+
+    template<int dim, typename Number>
+    void HyperbolicSystem::View<dim, Number>::post_process(const vector_type &U,
+                                                           Number t,
+                                                           MPI_Comm mpi_communicator,
+                                                           const ryujin::OfflineData<dim, Number>& offline_data_)
+    const
+    {
+      //do nothing
+    }
+
 
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -17,6 +17,8 @@
 #include <array>
 #include <functional>
 
+#include <offline_data.h>
+
 namespace ryujin
 {
   namespace Skeleton
@@ -404,6 +406,16 @@ namespace ryujin
                                            const Lambda & /*lambda*/) const
         {
           return state;
+        }
+
+        /**
+         * equation dependent postprocessing step
+         *
+         * must define, or leave as empty. do nothing.
+         */
+        void post_process(const vector_type &U, Number t, MPI_Comm, const OfflineData<dim, Number>&) const
+        {
+          //put your own postprocessing step here
         }
 
       }; /* HyperbolicSystem::View */

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
+#include <deal.II/base/tensor.h>
 
 #include <fstream>
 #include <future>
@@ -89,6 +90,12 @@ namespace ryujin
      * Run the high-level time loop.
      */
     void run();
+
+    /**
+     * Compute drag and lift of cylindrical case only
+     * returns a NUMBER of the drag.
+     */
+    dealii::Tensor<1,dim> calculate_drag_and_lift(const vector_type &U);
 
   protected:
     /**

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -91,12 +91,6 @@ namespace ryujin
      */
     void run();
 
-    /**
-     * Compute drag and lift of cylindrical case only
-     * returns a NUMBER of the drag.
-     */
-    dealii::Tensor<1,dim> calculate_drag_and_lift(const vector_type &U);
-
   protected:
     /**
      * @name Private methods for run()
@@ -150,6 +144,7 @@ namespace ryujin
     bool enable_output_levelsets_;
     bool enable_compute_error_;
     bool enable_compute_quantities_;
+    bool post_process_;
 
     unsigned int output_checkpoint_multiplier_;
     unsigned int output_full_multiplier_;

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1209,16 +1209,17 @@ namespace ryujin
     if(pressure.has_ghost_elements() != true)
     {
       std::cout << "ghost elements not allowed " << std::endl;
-      exit(1);
+      exit(1);//TODO: remove
     }
     pressure.update_ghost_values();
 
-//    for(const auto& cell : offline_data->dof_handler.active_cell_iterators())
-//    {
-//      if(cell->is_locally_owned())
-//      {
-//        for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
-//        {
+    for(const auto& cell : offline_data_.dof_handler().active_cell_iterators())
+    {
+      if(cell->is_locally_owned())
+      {
+        for(unsigned int face = 0; face < cell->n_faces(); ++face)
+        {
+          std::cout << "inside loops, cell, locally owned, face " << face << std::endl;
 //          if(cell->face(face)->at_boundary()
 //              && cell->face(face)->boundary_id() == Boundaries::free_slip)
 //          {
@@ -1252,9 +1253,9 @@ namespace ryujin
 //              }//loop over q points
 //            }//if face on the object (circle in the domain)
 //          }//if cell face is at boundary
-//        }//face loop
-//      }//locally_owned cells
-//    }//cell loop
+        }//face loop
+      }//locally_owned cells
+    }//cell loop
 //
 //    //now, sum the values across all processes.
 //    lift = Utilities::MPI::sum(lift, mpi_communicator);

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1134,8 +1134,8 @@ namespace ryujin
     const auto names = view.component_names;
 
     const Number gamma = 1.4;
-    std::cout << "names " << names[0] << std::endl;
-    std::cout << "gama " << gamma << std::endl;
+//    std::cout << "names " << names[0] << std::endl;
+//    std::cout << "gama " << gamma << std::endl;
 
     //some general variables
     Point<dim> disk_center;//center at 0,0 for every case, how to not hardcode this?FIXME: how do we calculate disk center from the information in mesh generation?
@@ -1153,7 +1153,7 @@ namespace ryujin
     scalar_type density, pressure;
     std::vector<scalar_type> momentum(dim);
 
-    std::cout << "inside calc before density partition" << std::endl;
+//    std::cout << "inside calc before density partition" << std::endl;
     //initialize partitions
     density.reinit(offline_data_.scalar_partitioner(), mpi_communicator_);
     pressure.reinit(offline_data_.scalar_partitioner(), mpi_communicator_);
@@ -1240,7 +1240,7 @@ namespace ryujin
             //check if we are on circle
             if(distance < disk_radius + 1e-6)//TODO: ask W for a better way to decide if a face is on circle
             {
-              std::cout << "face center on circle: " << face_center << std::endl;
+//              std::cout << "face center on circle: " << face_center << std::endl;
               fe_face_values.reinit(cell, face);
 
               //pressure values

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1103,4 +1103,109 @@ namespace ryujin
     }
   }
 
+  template<typename Description, int dim, typename Number>
+  Tensor<1,dim> TimeLoop<Description, dim, Number>::calculate_drag_and_lift(const vector_type &U)
+  {
+//
+//    //some general variables
+//    Point<dim> disk_center;//center at 0,0 for every case, how to not hardcode this?FIXME: how do we calculate disk center from the information in mesh generation?
+//    double disk_radius =  offline_data->getDiscretization()->getDiskDiameter()* 0.5;
+//    //first, set up the finite element, the data, and the facevalues
+//    auto fe = offline_data->getDiscretization()->finite_element;//the finite element
+//    const int degree = fe.degree;
+//    QGauss<dim-1> face_quadrature_formula(degree + 2);
+//    const int n_q_points = face_quadrature_formula.size();
+//
+//    std::vector<double>      pressure_values(n_q_points);
+//
+//    Tensor<1,dim> normal_vector;
+//    SymmetricTensor<2,dim> fluid_stress;
+//    SymmetricTensor<2,dim> fluid_pressure;
+//    Tensor<1,dim> forces;
+//
+//    FEFaceValues<dim> fe_face_values(fe, face_quadrature_formula,
+//        update_values | update_quadrature_points | update_gradients |
+//        update_JxW_values | update_normal_vectors); //the face values
+//
+//    double drag = 0.;
+//    double lift = 0.;
+//
+//    // Create vectors that store the locally owned parts on every process
+//    vector_type U_local;
+//    for(unsigned int i = 0; i<ProblemDescription<dim>::n_solution_variables; ++i)
+//      U_local[i] = U[i];
+//
+//    const double gamma = ProblemDescription<dim>::gamma;
+//
+//    //convert E to pressure
+//    for (unsigned int k=0; k<offline_data->n_locally_owned; k++)
+//    {
+//      //calculate momentum norm squared
+//      const double &E = U_local[dim+1].local_element(k);
+//      const double &rho = U_local[0].local_element(k);
+//      double m_square = 0;
+//      for(int d=0; d<dim; d++)
+//        m_square += std::pow(U_local[1+d].local_element(k),2);
+//
+//      //pressure = (gamma-1)*internal_energy
+//      U_local[dim+1].local_element(k) =  (gamma - 1.0) * (E - 0.5*m_square/rho);
+//    }
+//
+//    // Finally do a ghost exchange where every process gets the elements it needs from other processes:
+//    for(unsigned int i = 0; i<ProblemDescription<dim>::n_solution_variables; ++i)
+//      U_local[i].update_ghost_values();
+//
+//    for(const auto& cell : offline_data->dof_handler.active_cell_iterators())
+//    {
+//      if(cell->is_locally_owned())
+//      {
+//        for(unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+//        {
+//          if(cell->face(face)->at_boundary()
+//              && cell->face(face)->boundary_id() == Boundaries::free_slip)
+//          {
+//            //if on circle, we do the calculation
+//            //first, find if the face center is on the circle
+//            const Point<dim> face_center = cell->face(face)->center(true);//center of the face on the manifold
+//            const double distance = face_center.distance(disk_center);
+//
+//            //check if we are on circle
+//            if(distance < disk_radius + 1e-6 && distance > disk_radius - 1e-6)
+//            {
+//              fe_face_values.reinit(cell, face);
+//
+//              //pressure values
+//              fe_face_values.get_function_values(U_local[dim+1], pressure_values);
+//
+//              //now, loop over quadrature points calculating their contribution to the forces acting on the face
+//              for(int q = 0; q < n_q_points; ++q)
+//              {
+//                normal_vector = -fe_face_values.normal_vector(q);
+//
+//                //form the contributions from pressure
+//                for(unsigned int d = 0; d < dim; ++d)
+//                  fluid_pressure[d][d] = pressure_values[q];
+//
+//                fluid_stress = - fluid_pressure;//for the euler equations, the only contribution to stresses comes from pressure
+//                forces = fluid_stress*normal_vector*fe_face_values.JxW(q);
+//                //the drag is in the x direction, the lift is in the y direction but FIXME: does this hold true in higher dimension? look below for this
+//                drag += forces[0];
+//                lift += forces[1];
+//              }//loop over q points
+//            }//if face on the object (circle in the domain)
+//          }//if cell face is at boundary
+//        }//face loop
+//      }//locally_owned cells
+//    }//cell loop
+//
+//    //now, sum the values across all processes.
+//    lift = Utilities::MPI::sum(lift, mpi_communicator);
+//    drag = Utilities::MPI::sum(drag, mpi_communicator);
+//
+//    forces[0] = drag;
+//    forces[1] = lift;
+//
+//    return forces;
+  }
+
 } // namespace ryujin

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -191,6 +191,11 @@ namespace ryujin
                   "number of threads (per rank). If set to false then a plain "
                   "average per thread \"CPU\" throughput value is computed by "
                   "using the umodified total accumulated CPU time.");
+
+    post_process_ = false;
+    add_parameter("enable custom postproc step",
+                  post_process_,
+                  "do a user defined postprocessing step");
   }
 
 
@@ -368,12 +373,10 @@ namespace ryujin
       if (t >= t_final_)
         break;
 
-      /* Do a time step: */
-      dealii::Tensor<1,dim> forces = calculate_drag_and_lift(U);
-      drag.push_back(forces[0]);
-      lift.push_back(forces[1]);
-      time.push_back(t);
+
       const auto tau = time_integrator_.step(U, t);
+      if(post_process_)
+        postprocessor_.post_process_data(U,t);
       t += tau;
 
       /* Print and record cycle statistics: */
@@ -409,14 +412,6 @@ namespace ryujin
       compute_error(U, t);
     }
 
-    if(mpi_rank_ == 0)
-    {
-      for(unsigned int i=0; i< drag.size(); i++)
-      {
-        std::cout << "drag: " << drag.at(i)
-              << " lift: " << lift.at(i) << " t: " << time.at(i) << std::endl;
-      }
-    }
 
 #ifdef WITH_VALGRIND
     CALLGRIND_DUMP_STATS;
@@ -1124,157 +1119,6 @@ namespace ryujin
         logfile_ << "\n" << output.str() << std::flush;
       }
     }
-  }
-
-  template<typename Description, int dim, typename Number>
-  Tensor<1,dim> TimeLoop<Description, dim, Number>::calculate_drag_and_lift(const vector_type &U)
-  {
-
-    const auto view = hyperbolic_system_.template view<2, double>();
-    const auto names = view.component_names;
-
-    const Number gamma = 1.4;
-//    std::cout << "names " << names[0] << std::endl;
-//    std::cout << "gama " << gamma << std::endl;
-
-    //some general variables
-    Point<dim> disk_center;//center at 0,0 for every case, how to not hardcode this?FIXME: how do we calculate disk center from the information in mesh generation?
-    double disk_radius = 0.25;
-    disk_radius +=0;//todo remove
-
-    //first, set up the finite element, the data, and the facevalues
-    FE_Q<dim> fe(ORDER_FINITE_ELEMENT);//the finite element
-    const int degree = fe.degree;
-    QGauss<dim-1> face_quadrature_formula(degree + 2);
-    const int n_q_points = face_quadrature_formula.size();
-
-    std::vector<double>      pressure_values(n_q_points);
-
-    scalar_type density, pressure;
-    std::vector<scalar_type> momentum(dim);
-
-//    std::cout << "inside calc before density partition" << std::endl;
-    //initialize partitions
-    density.reinit(offline_data_.scalar_partitioner(), mpi_communicator_);
-    pressure.reinit(offline_data_.scalar_partitioner(), mpi_communicator_);
-    for(unsigned int c=0; c < dim; c++)
-      momentum.at(c).reinit(offline_data_.scalar_partitioner(), mpi_communicator_);
-
-    Tensor<1,dim> normal_vector;
-    SymmetricTensor<2,dim> fluid_stress;
-    SymmetricTensor<2,dim> fluid_pressure;
-    Tensor<1,dim> forces;
-
-    FEFaceValues<dim> fe_face_values(fe, face_quadrature_formula,
-        update_values | update_quadrature_points | update_gradients |
-        update_JxW_values | update_normal_vectors); //the face values
-
-    double drag = 0.;
-    double lift = 0.;
-
-
-    // Create vectors that store the locally owned parts on every process
-    U.extract_component(density, 0);//extract density
-    U.extract_component(pressure, dim+1);//extract density
-
-    //extract momentum, and convert to velocity
-    for(int c=0; c<dim; c++)
-    {
-      int comp = c+1;//momentum is stored in positions [1,...,dim], so add one to c
-      U.extract_component(momentum.at(c), comp);
-    }
-
-    //extract energy
-    U.extract_component(pressure, dim+1);
-
-    //convert E to pressure
-    for (unsigned int k=0; k<offline_data_.n_locally_owned(); k++)
-    {
-      //calculate momentum norm squared
-      const double &E = pressure.local_element(k);
-      const double &rho = density.local_element(k);
-      double m_square = 0;
-      for(int d=0; d<dim; d++)
-        m_square += std::pow(momentum.at(d).local_element(k),2);
-
-      //pressure = (gamma-1)*internal_energy
-      pressure.local_element(k) =  (gamma - 1.0) * (E - 0.5*m_square/rho);
-    }
-
-
-    if((pressure.has_ghost_elements() != true) || (density.has_ghost_elements() != true)
-        ||(momentum.at(0).has_ghost_elements() != true) || (momentum.at(1).has_ghost_elements() != true))
-    {
-      //TODO: make this some type of exception
-      std::cout << "ghost elements not allowed " << std::endl;
-      std::cout << "pressure " << (pressure.has_ghost_elements() != true) << std::endl;
-      std::cout << "momx " << (momentum.at(0).has_ghost_elements() != true) << std::endl;
-      std::cout << "momy " << (momentum.at(1).has_ghost_elements() != true) << std::endl;
-      std::cout << "density " << (density.has_ghost_elements() != true) << std::endl;
-
-      exit(1);//TODO: remove, for now, I want this to just quit the program
-    }
-    density.update_ghost_values();
-    pressure.update_ghost_values();
-    for(auto mom: momentum)
-      mom.update_ghost_values();
-
-
-    for(const auto& cell : offline_data_.dof_handler().active_cell_iterators())
-    {
-      if(cell->is_locally_owned())
-      {
-        for(unsigned int face = 0; face < cell->n_faces(); ++face)
-        {
-          if(cell->face(face)->at_boundary()
-              && cell->face(face)->boundary_id() == ryujin::Boundary::slip)
-          {
-            //if on circle, we do the calculation
-            //first, find if the face center is on the circle
-            const auto tria_iterator = cell->face(face);//->center(true);//center of the face on the manifold
-            const Point<dim> face_center = tria_iterator->center();
-            const double distance = face_center.distance(disk_center);
-
-//            std::cout << "face center " << face_center << std::endl;
-//            std::cout << "distance " << distance << std::endl;
-            //check if we are on circle
-            if(distance < disk_radius + 1e-6)//TODO: ask W for a better way to decide if a face is on circle
-            {
-//              std::cout << "face center on circle: " << face_center << std::endl;
-              fe_face_values.reinit(cell, face);
-
-              //pressure values
-              fe_face_values.get_function_values(pressure, pressure_values);
-
-              //now, loop over quadrature points calculating their contribution to the forces acting on the face
-              for(int q = 0; q < n_q_points; ++q)
-              {
-                normal_vector = -fe_face_values.normal_vector(q);
-
-                //form the contributions from pressure
-                for(unsigned int d = 0; d < dim; ++d)
-                  fluid_pressure[d][d] = pressure_values[q];
-
-                fluid_stress = - fluid_pressure;//for the euler equations, the only contribution to stresses comes from pressure
-                forces = fluid_stress*normal_vector*fe_face_values.JxW(q);
-                //the drag is in the x direction, the lift is in the y direction but FIXME: does this hold true in higher dimension? look below for this
-                drag += forces[0];
-                lift += forces[1];
-              }//loop over q points
-            }//if face on the object (circle in the domain)
-          }//if cell face is at boundary
-        }//face loop
-      }//locally_owned cells
-    }//cell loop
-
-    //now, sum the values across all processes.
-    lift = dealii::Utilities::MPI::sum(lift, mpi_communicator_);
-    drag = dealii::Utilities::MPI::sum(drag, mpi_communicator_);
-
-    forces[0] = drag;
-    forces[1] = lift;
-
-    return forces;
   }
 
 } // namespace ryujin


### PR DESCRIPTION
added capability for a user defined postprocessing step, which in particular had access to DOF info through offline_data.

Please critique the style of output I have chosen inside euler/hyperbolic_system.h, in particular, I wrote it to print the drag and lift to terminal, and will collect the info from a .log file. However, I may like to store this in some kind of vector, so that when I later adapt this into the MGRIT algorithm, I can call a function after every iteration and at each coarse time point. 

My thinking is that the data may be difficult to understand if I simply print this calculation out at each coarse time point.

Problem is, I do not know hao to make this general. Why should a user have to provide, for example, a vector to the function if their postprocessing step has no need for a storage vector. Maybe I can template on some type of return type?